### PR TITLE
#20 Fix safari 10.1 bug, that incorrectly decoded a character.

### DIFF
--- a/test/index.test.js
+++ b/test/index.test.js
@@ -253,10 +253,11 @@ describe(PREFIX + 'Others', function () {
         a: '你好',
         b: '<script>',
         c: 'http://a.com/?c=7&d=8#!/asd',
-        d: 'hello world'
+        d: 'hello world',
+        e: '+'
     };
 
-    var testStr = 'a=%E4%BD%A0%E5%A5%BD&b=%3Cscript%3E&c=http%3A%2F%2Fa.com%2F%3Fc%3D7%26d%3D8%23%21%2Fasd&d=hello+world';
+    var testStr = 'a=%E4%BD%A0%E5%A5%BD&b=%3Cscript%3E&c=http%3A%2F%2Fa.com%2F%3Fc%3D7%26d%3D8%23%21%2Fasd&d=hello+world&e=%2B';
 
     it('URL encode', function () {
         var a = new URLSearchParams(testObj);


### PR DESCRIPTION
- use full polyfill if the implementation of native URLSearchParams is faulty (Safari 10.1).
- add a check if pluses are decoded correctly