### PR TITLE
Fix array encoding.

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,7 +35,6 @@
         if (search instanceof URLSearchParams || search instanceof URLSearchParamsPolyfill) {
             search = search.toString();
         }
-
         this [__URLSearchParams__] = parseToDict(search);
     }
 
@@ -110,6 +109,7 @@
      * @returns {string}
      */
     prototype.toString = function() {
+
         var dict = this[__URLSearchParams__], query = [], i, key, name, value;
         for (key in dict) {
             name = encode(key);
@@ -263,10 +263,25 @@
         var dict = {};
 
         if (typeof search === "object") {
-            for (var i in search) {
-                if (search.hasOwnProperty(i)) {
-                    var str = typeof search [i] === 'string' ? search [i] : JSON.stringify(search [i]);
-                    appendTo(dict, i, str);
+            for (var key in search) {
+                if (search.hasOwnProperty(key)) {
+                    if (Array.isArray(search[key])) {
+                        var arrayProp = search[key]
+                        var arrayLength = arrayProp.length;
+                        if (arrayLength === 0) {
+                            appendTo(dict, key, '')
+                        }
+                        else {
+                            for (j = 0; j < arrayProp.length; j++) {
+                                value = arrayProp[j];
+                                appendTo(dict, key, value);
+                            }
+                        }
+                    }
+                    else {
+                        var str = typeof search [key] === 'string' ? search [key] : JSON.stringify(search [key]);
+                        appendTo(dict, key, str);
+                    }
                 }
             }
 
@@ -299,7 +314,7 @@
         if (name in dict) {
             dict[name].push('' + value);
         } else {
-            dict[name] = ['' + value];
+            dict[name] = Array.isArray(value) ? value : ['' + value];
         }
     }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -42,7 +42,20 @@ describe(PREFIX + 'Constructor', function () {
             f: "hello"
         });
 
-        expect(a.toString()).to.be.equal('a=1&b=true&c=null&d=%5B%5D&e=%7B%22f%22%3A%22g%22%7D&f=hello');
+        expect(a.toString()).to.be.equal('a=1&b=true&c=null&d=&e=%7B%22f%22%3A%22g%22%7D&f=hello');
+    });
+
+    it('Construct with an object with a non-empty array', function () {
+        var a = new URLSearchParams({
+            a: 1,
+            b: true,
+            c: null,
+            d: [1, 2, 3],
+            e: {f: "g"},
+            f: "hello"
+        });
+
+        expect(a.toString()).to.be.equal('a=1&b=true&c=null&d=1&d=2&d=3&e=%7B%22f%22%3A%22g%22%7D&f=hello');
     });
 
     it('Construct an empty object', function () {


### PR DESCRIPTION
Brackets are getting encoded with arrays, which doesn't play nicely with the way that the spec indicates arrays should be serialized. This resolves this by checking for an array value, and then handling it appropriately.