### PR TITLE
Updated 'keys' and 'values' prototype not to wrap elements in own array

### DIFF
--- a/index.js
+++ b/index.js
@@ -183,7 +183,7 @@
     USPProto.keys = USPProto.keys || function() {
         var items = [];
         this.forEach(function(item, name) {
-            items.push([name]);
+            items.push(name);
         });
         return makeIterator(items);
     };
@@ -197,7 +197,7 @@
     USPProto.values = USPProto.values || function() {
         var items = [];
         this.forEach(function(item) {
-            items.push([item]);
+            items.push(item);
         });
         return makeIterator(items);
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "url-search-params-polyfill",
-  "version": "3.0.0",
+  "version": "4.0.0",
   "description": "a simple polyfill for javascript URLSearchParams",
   "homepage": "https://github.com/jerrybendy/url-search-params-polyfill",
   "main": "index.js",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -228,6 +228,8 @@ describe(PREFIX + 'Iterator', function () {
             ret.push(key);
         }
         expect(ret.join(';')).to.be.equal('a;b;c');
+
+        expect(Array.from(obj.keys())).to.be.eql(['a','b','c']);
     });
 
     it('values', function () {
@@ -237,6 +239,8 @@ describe(PREFIX + 'Iterator', function () {
             ret.push(value);
         }
         expect(ret.join(';')).to.be.equal('1;2;3');
+
+        expect(Array.from(obj.values())).to.be.eql(['1', '2', '3']);
     });
 
 });


### PR DESCRIPTION
I believe there is a defect in the `keys` and `values` methods where each element is being converted into a single-valued array.

The existing tests miss this issue because `Array.join` combines the _string_ representation of each element.  Because the value was an array of single-valued arrays (`[['a'], ['b'], ['c']]`) the `toString()` on each element resulting from the `.join(';')` produces the same `a;b;c` result as an array of ['a', 'b', 'c'] would have.

I removed the square brackets in the `push` that was causing each element to be an array, and added a new test expectation to each case.  Because this breaks backward compatibility I also incremented the major version.