### PR TITLE
Fix detection of missing 'get' function on URLSearchParams

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@
 (function(self) {
     'use strict';
 
-    var nativeURLSearchParams = self.URLSearchParams ? self.URLSearchParams : null,
+    var nativeURLSearchParams = (self.URLSearchParams && self.URLSearchParams.prototype.get) ? self.URLSearchParams : null,
         isSupportObjectConstructor = nativeURLSearchParams && (new nativeURLSearchParams({a: 1})).toString() === 'a=1',
         // There is a bug in safari 10.1 (and earlier) that incorrectly decodes `%2B` as an empty space and not a plus.
         decodesPlusesCorrectly = nativeURLSearchParams && (new nativeURLSearchParams('s=%2B').get('s') === '+'),
@@ -131,15 +131,16 @@
     /*
      * Apply polifill to global object and append other prototype into it
      */
-    self.URLSearchParams = useProxy ?
-        // Safari 10.0 doesn't support Proxy, so it won't extend URLSearchParams on safari 10.0
-        new Proxy(nativeURLSearchParams, {
-            construct: function(target, args) {
-                return new target((new URLSearchParamsPolyfill(args[0]).toString()));
-            }
-        }) :
-        URLSearchParamsPolyfill;
-
+    Object.defineProperty(self, 'URLSearchParams', {
+        value: (useProxy ?
+            // Safari 10.0 doesn't support Proxy, so it won't extend URLSearchParams on safari 10.0
+            new Proxy(nativeURLSearchParams, {
+                construct: function(target, args) {
+                    return new target((new URLSearchParamsPolyfill(args[0]).toString()));
+                }
+            }) :
+            URLSearchParamsPolyfill)
+    });
 
     var USPProto = self.URLSearchParams.prototype;
 


### PR DESCRIPTION
Fix assignment of URLSearchParams on the global object

This appened on some random browsers like
Mozilla/5.0 (Linux; Android 6.0.1; SM-G900F Build/LRX22C) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/3.0 Chrome/38.0.2125.102 Mobile Safari/537.36
Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.98 Safari/537.36
Mozilla/5.0 (Linux; Android 8.0.0; SAMSUNG SM-J330FN Build/R16NW) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/8.2 Chrome/63.0.3239.111 Mobile Safari/537.36
Mozilla/5.0 (Linux; Android 8.0.0; SM-G950F) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/71.0.3578.99 Mobile Safari/537.36

See https://github.com/jerrybendy/url-search-params-polyfill/issues/34