### PR TITLE
Add `;` so some ofbfuscators does not break

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@
 
     // There is a bug in Safari 10.1 and `Proxy`ing it is not enough.
     var forSureUsePolyfill = !decodesPlusesCorrectly;
-    var useProxy = (!forSureUsePolyfill && nativeURLSearchParams && !isSupportObjectConstructor && self.Proxy)
+    var useProxy = (!forSureUsePolyfill && nativeURLSearchParams && !isSupportObjectConstructor && self.Proxy);
     /*
      * Apply polifill to global object and append other prototype into it
      */


### PR DESCRIPTION
Hello,
with our legacy obfuscation library we have issue in browser `SyntaxError: Unexpected identifier 'Object'. Expected ';' after variable declaration.`

It is fixed by adding (optional) semicolon.